### PR TITLE
new import and audit

### DIFF
--- a/audit_records.js
+++ b/audit_records.js
@@ -1,0 +1,25 @@
+const audit_records = (con) => {
+    return new Promise ((resolve) => {
+        console.log(new Date(), "Fetching audit report");
+ 
+        // fetch and collate host data
+        let q = `SELECT timestamp FROM tbl_hostmemdata GROUP BY timestamp ORDER BY timestamp ASC`;
+        con.query(q, function (err, res) {
+            if (err) throw err;
+            let r_data = {}
+            for (let i of res){
+                let d = new Date(i.timestamp);
+                let fd = `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`
+                if (r_data.hasOwnProperty(fd)){
+                    r_data[fd] += 1;
+                } else {
+                    r_data[fd] = 1;
+                }
+            }
+            resolve(r_data);
+        });
+    });
+ }
+ module.exports = {
+     audit_records: audit_records,
+ };

--- a/collate_data.js
+++ b/collate_data.js
@@ -12,59 +12,59 @@ const collate_data = (con) => {
                ORDER BY timestamp`;
       con.query(q, function (err, res) {
          if (err) throw err;
-               let tmp_v = [];
-               for (let x of res){
-                  tmp_v.push(`('${x.host_id}', ${x.timestamp}, ${x.memory.toFixed(5)})`);
+         let tmp_v = [];
+         for (let x of res){
+            tmp_v.push(`('${x.host_id}', ${x.timestamp}, ${x.memory.toFixed(5)})`);
+         }
+         if (tmp_v.length > 0){
+            // insert collated host data into db
+            let insert_q = `REPLACE INTO tbl_hostmemdata (host_id, timestamp, memory) VALUES ${tmp_v.join(', ')}`;
+            con.query(insert_q, function (err, res) {
+               if (err) throw err;
+               if (process.env.LOG_LEVEL == 'debug'){
+                  console.log(new Date(), res);
                }
-               if (tmp_v.length > 0){
-               // insert collated host data into db
-               let insert_q = `REPLACE INTO tbl_hostmemdata (host_id, timestamp, memory) VALUES ${tmp_v.join(', ')}`;
-               con.query(insert_q, function (err, res) {
-                  if (err) throw err;
-                  if (process.env.LOG_LEVEL == 'debug'){
-                     console.log(new Date(), res);
-                  }
 
-                  // collate on namespace
-                  let namespace_q = `SELECT namespaces,
-                                          timestamp,
-                                          SUM(memory) as memory
-                                       FROM tbl_pgi2host
-                                       JOIN tbl_pgidata USING (pgi_id)
-                                       GROUP BY namespaces, timestamp
-                                       ORDER BY timestamp`;
-                  con.query(namespace_q, function (err, res) {
-                     if (err) throw err;
-                     let tmp_v = [], tmp_d = [];
-                     for (let x of res){
-                           tmp_v.push(`('${x.namespaces}', ${x.timestamp}, ${x.memory.toFixed(5)})`);
-                           tmp_d.push(x.timestamp);
-                     }
-                     if (tmp_v.length > 0){
-                           // insert collated host data into db
-                           let insertns_q = `REPLACE INTO tbl_nsmemdata (namespaces, timestamp, memory) VALUES ${tmp_v.join(', ')}`;
-                           con.query(insertns_q, function (err, res) {
+               // collate on namespace
+               let namespace_q = `SELECT namespaces,
+                                       timestamp,
+                                       SUM(memory) as memory
+                                    FROM tbl_pgi2host
+                                    JOIN tbl_pgidata USING (pgi_id)
+                                    GROUP BY namespaces, timestamp
+                                    ORDER BY timestamp`;
+               con.query(namespace_q, function (err, res) {
+                  if (err) throw err;
+                  let tmp_v = [], tmp_d = [];
+                  for (let x of res){
+                        tmp_v.push(`('${x.namespaces}', ${x.timestamp}, ${x.memory.toFixed(5)})`);
+                        tmp_d.push(x.timestamp);
+                  }
+                  if (tmp_v.length > 0){
+                        // insert collated host data into db
+                        let insertns_q = `REPLACE INTO tbl_nsmemdata (namespaces, timestamp, memory) VALUES ${tmp_v.join(', ')}`;
+                        con.query(insertns_q, function (err, res) {
+                           if (err) throw err;
+                           if (process.env.LOG_LEVEL == 'debug'){
+                              console.log(new Date(), res);
+                           }
+
+                           // remove the old detail data
+                           let cleanup_q = `DELETE FROM tbl_pgidata WHERE timestamp IN (${tmp_d.join(', ')})`;
+                           con.query(cleanup_q, function (err, res) {
                               if (err) throw err;
                               if (process.env.LOG_LEVEL == 'debug'){
                                  console.log(new Date(), res);
                               }
 
-                              // remove the old detail data
-                              let cleanup_q = `DELETE FROM tbl_pgidata WHERE timestamp IN (${tmp_d.join(', ')})`;
-                              con.query(cleanup_q, function (err, res) {
-                                 if (err) throw err;
-                                 if (process.env.LOG_LEVEL == 'debug'){
-                                    console.log(new Date(), res);
-                                 }
-
-                                 resolve(`Data collated`);
-                              });
+                              resolve(`Data collated`);
                            });
-                     } else {
-                           resolve(`Nothing to collate`);
-                     }
-                  });
+                        });
+                  } else {
+                        resolve(`Nothing to collate`);
+                  }
                });
+            });
          } else {
                resolve(`Nothing to collate`);
          }

--- a/fetch_pgi_data.js
+++ b/fetch_pgi_data.js
@@ -1,4 +1,4 @@
-const fetch_pgi = (tenantURL, apiKey, processTags, con, pastHour) => {
+const fetch_pgi = (tenantURL, apiKey, processTags, con, pastHour, timeBox) => {
     // Load required packages
     const fetch = require('node-fetch'); // for making http calls
 
@@ -14,7 +14,7 @@ const fetch_pgi = (tenantURL, apiKey, processTags, con, pastHour) => {
     // Fetch metrics for memory utilization
     (async () => {
             apiURI = '/api/v2/metrics/query'
-            let timeBox = `&from=now-${pastHour}h/h&to=now-${pastHour - 1}h/h`;
+            timeBox = timeBox ? timeBox : `&from=now-${pastHour}h/h&to=now-${pastHour - 1}h/h`;
             let queryString = `?metricSelector=builtin:tech.generic.mem.workingSetSize:max&resolution=1h${timeBox}`;
             let formatTags = Array.isArray(processTags) ? `&entitySelector=type(PROCESS_GROUP_INSTANCE),tag(${processTags.join('),tag(')})` : '';
             let r = await fetch(`${tenantURL}${apiURI}${queryString}&pageSize=1000${formatTags}`, {'headers': headers});


### PR DESCRIPTION
Changed the PGI import API to allow for human readable dates to be supplied as start and end.

To use, access:
/pgi/${start} to run for one day
/pgi/${start}/${end} for multiple days

Example:
/pgi/1.2.2019/1.10.2019


Also added an audit API to see if historic data is complete.

To use, access:
/audit

The API will return JSON with the dates covered and the number of hours on that date. Using this, you can see if there are 24 entries for each date and that there are no gaps between dates.