### PR TITLE
Modify collation behavior

### DIFF
--- a/collate_records.js
+++ b/collate_records.js
@@ -1,0 +1,15 @@
+const collate_records = (con) => {
+    return new Promise ((resolve) => {
+        console.log(new Date(), "Collating historic data");
+ 
+        // fetch and collate host data
+        let q = `CALL CollateHistoric();`;
+        con.query(q, function (err, res) {
+            if (err) throw err;
+            resolve("Collation initiated.");
+        });
+    });
+ }
+ module.exports = {
+     collate_records: collate_records
+ };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const fetchpgi = require('./fetch_pgi_data').fetch_pgi; // for fetching pgi data
 const fetchns = require('./fetch_namespaces').fetch_ns; // for fetching namespaces
 const server_report = require('./k8s_server_report').server_report; // returns the server HU calculations
 const audit_records = require('./audit_records').audit_records; // anylizes data in DB and reports back
+const collate_records = require('./collate_records').collate_records; // processes imported historic data
 const schedule = require('node-schedule'); // for scheduling jobs
 const express = require('express'); // for exposing api endpoint to query data
 const app = express();
@@ -133,6 +134,12 @@ app.get('/nsimport', async (req, res) => {
 
 app.get('/audit', async (req, res) => {
     audit_records(con).then(m => {
+        res.json(m);
+    })
+})
+
+app.get('/collate', async (req, res) => {
+    collate_records(con).then(m => {
         res.json(m);
     })
 })

--- a/mysql/procedure.sql
+++ b/mysql/procedure.sql
@@ -1,30 +1,60 @@
 DELIMITER $$
-CREATE PROCEDURE `CollateData`()
+CREATE PROCEDURE `CollateData` ()  SQL SECURITY INVOKER
 BEGIN
-
-REPLACE INTO tbl_hostmemdata
-        (host_id, timestamp, memory)
-    SELECT host_id,
-           timestamp,
-           SUM(memory) as memory
-    FROM tbl_pgi2host
-        JOIN tbl_pgidata USING (pgi_id)
-        GROUP BY host_id, timestamp;
-
-REPLACE INTO tbl_nsmemdata
-        (namespaces, timestamp, memory)
-    SELECT COALESCE (namespaces, 'none'),
-           timestamp,
-           SUM(memory) as memory
-    FROM tbl_pgi2host
-        JOIN tbl_pgidata USING (pgi_id)
-        GROUP BY namespaces, timestamp;
-
-DELETE FROM tbl_pgidata
-    WHERE timestamp IN (
-        SELECT timestamp FROM tbl_hostmemdata
-          GROUP BY timestamp
-    );
+    DECLARE MaxTS BIGINT;
     
-END$$
+    SELECT MAX(timestamp)
+      INTO MaxTS
+      FROM tbl_pgidata;
+    
+    REPLACE INTO tbl_hostmemdata (host_id, timestamp, memory)
+      SELECT host_id, timestamp, SUM(memory) as memory
+      FROM tbl_pgi2host
+      JOIN tbl_pgidata USING (pgi_id)
+      WHERE host_id IS NOT NULL
+      AND timestamp=MaxTS
+      GROUP BY host_id, timestamp;
+
+    REPLACE INTO tbl_nsmemdata (namespaces, timestamp, memory)
+      SELECT COALESCE (namespaces, 'none'), timestamp, SUM(memory) as memory
+      FROM tbl_pgi2host
+      JOIN tbl_pgidata
+      USING (pgi_id)
+      WHERE namespaces IS NOT NULL
+      AND timestamp=MaxTS
+      GROUP BY namespaces, timestamp;
+
+    DELETE FROM tbl_pgidata
+      WHERE timestamp=MaxTS;
+  END$$
+
+CREATE PROCEDURE `CollateHistoric` ()  SQL SECURITY INVOKER
+BEGIN
+    DECLARE MaxTS BIGINT;
+    
+    SELECT MAX(timestamp)
+      INTO MaxTS
+      FROM tbl_pgidata;
+    
+    REPLACE INTO tbl_hostmemdata (host_id, timestamp, memory)
+      SELECT host_id, timestamp, SUM(memory) as memory
+      FROM tbl_pgi2host
+      JOIN tbl_pgidata USING (pgi_id)
+      WHERE host_id IS NOT NULL
+      AND timestamp < MaxTS
+      GROUP BY host_id, timestamp;
+
+    REPLACE INTO tbl_nsmemdata (namespaces, timestamp, memory)
+      SELECT COALESCE (namespaces, 'none'), timestamp, SUM(memory) as memory
+      FROM tbl_pgi2host
+      JOIN tbl_pgidata
+      USING (pgi_id)
+      WHERE namespaces IS NOT NULL
+      AND timestamp < MaxTS
+      GROUP BY namespaces, timestamp;
+
+    DELETE FROM tbl_pgidata
+      WHERE timestamp < MaxTS;
+  END$$
+
 DELIMITER ;


### PR DESCRIPTION
To avoid conflicts when processing raw data, the following has been done:
- Scheduled collation only pulls in the most recent hour
- Added new procedure to process historic data, grabbing anything older than the oldest timestamp
- Exposed new historic data processing procedure via /collate api endpoint