### PR TITLE
Date select for report and audit enhancement

### DIFF
--- a/audit_records.js
+++ b/audit_records.js
@@ -3,7 +3,7 @@ const audit_records = (con) => {
         console.log(new Date(), "Fetching audit report");
  
         // fetch and collate host data
-        let q = `SELECT timestamp FROM tbl_hostmemdata GROUP BY timestamp ORDER BY timestamp ASC`;
+        let q = `SELECT timestamp,count(*) AS num_records FROM tbl_hostmemdata GROUP BY timestamp ORDER BY timestamp ASC`;
         con.query(q, function (err, res) {
             if (err) throw err;
             let r_data = {}
@@ -11,9 +11,12 @@ const audit_records = (con) => {
                 let d = new Date(i.timestamp);
                 let fd = `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`
                 if (r_data.hasOwnProperty(fd)){
-                    r_data[fd] += 1;
+                    r_data[fd].hours += 1;
+                    r_data[fd].records += i.num_records;
                 } else {
-                    r_data[fd] = 1;
+                    r_data[fd] = {};
+                    r_data[fd].hours = 1;
+                    r_data[fd].records = i.num_records;
                 }
             }
             resolve(r_data);

--- a/index.js
+++ b/index.js
@@ -96,26 +96,39 @@ if (process.env.DISABLE_JOBS){
 
 // routes
 // host report
-app.get('/hostreport', async (req, res) => {
+app.get('/hostreport/:start?/:end?', async (req, res) => {
     let d = new Date(), from, to, fErr;
-    if (req.query.hasOwnProperty("start")){
-        from = (new Date(req.query.start)).getTime();
+    if (req.params.start){
+        console.log(req.params.start);
+        from = (new Date(req.params.start)).getTime();
+        console.log(from);
     } else {
         // default to last month
         d.setMonth(d.getMonth() - 1)
         const y = d.getFullYear(), m = d.getMonth();
         from = (new Date(y, m, 1)).getTime();
     }
-    if (req.query.hasOwnProperty("end")){
-        to = (new Date(req.query.end)).getTime();
+    if (req.params.end){
+        console.log(req.params.end);
+        to_d = new Date(req.params.end);
+        to_d.setMonth(to_d.getMonth() + 1);
+        to = to_d.getTime();
+        console.log(to);
     } else {
-        // default to now
-        to = (new Date()).getTime();
+        // default to one month
+        to_d = new Date(from);
+        to_d.setMonth(to_d.getMonth() + 1);
+        to  = to_d.getTime();
+        console.log(to);
     }
-   const getData = server_report(from, to, con);
-    getData.then((r) => {
-        res.send(r);
-    }).catch((e) => { console.log(new Date(), e) });
+    if (Number.isInteger(from) && Number.isInteger(to)){
+        const getData = server_report(from, to, con);
+        getData.then((r) => {
+            res.send(r);
+        }).catch((e) => { console.log(new Date(), e) });
+    } else {
+        res.send('Incorrect date format! Please use simple MonthYYY paterns (e.g. May2020)');
+    }
 });
 
 // import past pgi data

--- a/k8s_server_report.js
+++ b/k8s_server_report.js
@@ -21,8 +21,7 @@ const server_report = (from, to, con) => {
                     SUM(memory) as memory
                 FROM tbl_hostmemdata
                 JOIN tbl_hostdata USING (host_id)
-                WHERE timestamp >= ${from}
-                AND timestamp <= ${to}
+                WHERE timestamp BETWEEN ${from} AND ${to}
                 GROUP BY host_id, timestamp
                 ORDER BY timestamp`;
         con.query(q, function (err, res) {

--- a/package.json
+++ b/package.json
@@ -4,14 +4,10 @@
   "description": "Pulls metrics on host utilization and container memory consumption to facilitate ramped Dynatrace pricing and also internal chargeback reporting.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node ."
   },
   "author": "Erik Landsness",
   "bin": "index.js",
-  "scripts": {
-    "start": "node ."
-  },
   "pkg": {
     "assets": [
       ".env"


### PR DESCRIPTION
/hostreport endpoint now accepts optional start and end options for running the report during specific times:
examples: /hostreport/April2020 (will run the month of April 2020)
                  /hostreport/April2020/July2020 (will run the months of April 202 through July 2020)

/audit endpoint now exposes number of records per day in addition to number of hours. New JSON format is like this:
`'<date>': {
    'hours': <num_of_hours>,
    'records': <num_of_records>
}`